### PR TITLE
Fix range summary

### DIFF
--- a/R/summarize.R
+++ b/R/summarize.R
@@ -97,7 +97,7 @@ summarize_over_group <- function (data_summarized_over_time, group = NULL) {
       
      ans <-
        data_summarized_over_time |>
-       select(-starts_with("sum_"))
+       select(-starts_with("sum_")) |>
        arrange(name)
     return(ans)
   }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -61,6 +61,15 @@ summarize_over_time <- function (data_filtered) {
       avg_all_new_tests        = mean(all_new_tests             , na.rm = TRUE),
       sum_all_new_tests        = sum(all_new_tests              , na.rm = TRUE),
       avg_pos                  = avg_all_new_cases / avg_all_new_tests,
+      all_cum_cases            = all_cum_cases[1],
+      cap_cum_cases            = cap_cum_cases[1],
+      all_cum_deaths           = all_cum_deaths[1],
+      cap_cum_deaths           = cap_cum_deaths[1],
+      all_cum_tests            = all_cum_tests[1],
+      cap_cum_tests            = cap_cum_tests[1],
+      cap100k_cum_cases        = all_cum_cases[1] / pop_100k,
+      cap100k_cum_deaths       = all_cum_deaths[1] / pop_100k,
+      cap100k_cum_tests        = all_cum_tests[1] / pop_100k,
       avg_cap100k_new_cases    = mean(all_new_cases / pop_100k  , na.rm = TRUE),
       sum_cap100k_new_cases    = sum(all_new_cases / pop_100k   , na.rm = TRUE),
       avg_cap100k_new_deaths   = mean(all_new_deaths / pop_100k , na.rm = TRUE),
@@ -82,9 +91,14 @@ summarize_over_time <- function (data_filtered) {
 summarize_over_group <- function (data_summarized_over_time, group = NULL) {
 
   if (is.null(group) || group == "country") {
-    ans <-
-      data_summarized_over_time |>
-      arrange(name)
+      colnames(data_summarized_over_time) <- 
+        colnames(data_summarized_over_time) |>
+        str_replace_all(c("avg_" = ""))
+      
+     ans <-
+       data_summarized_over_time |>
+       select(-starts_with("sum_"))
+       arrange(name)
     return(ans)
   }
 


### PR DESCRIPTION
This PR uses cumulative values from `data_all` in a 'date' context in place of `sum(all_new_xxxx)` which gives only the new result for the selected date.

After bring in these cumulative variables, we then filter out the columns that start with `sum_` as we don't need them in a 'date' context. They are still retained in the 'range' context. We also remove the prefix `avg_` in the 'date' context (this then gives us the correct labels on the table), but retain it in the 'range' context.