### PR TITLE
make the summarize functions work for periodic data

### DIFF
--- a/R/summarize.R
+++ b/R/summarize.R
@@ -51,8 +51,9 @@ summarize_over_time <- function (data_filtered) {
   data_summarized_over_time <-
     data_grouped |> 
     summarize(
+      country = name[1],
       name = name[1],
-      unit = name[1],
+      unit = unit[1],
       pop_100k                 = mean(pop_100k, na.rm = TRUE),
       pop                      = mean(pop, na.rm = TRUE),
       avg_cap_new_cases        = mean(all_new_cases / pop       , na.rm = TRUE),


### PR DESCRIPTION
This PR improves the existing `summarize_over_` functions to be able to summarize data with a `period` column. This is helpful for the TRACK CHANGE OVER TIME sub-app, where data is summarized `daily`, `monthly`, `quarterly` and `yearly` instead of a single date or date range. 

Usage:
```
data_grpd <- group_by_period(data_all, period = "quarterly") |>
  select(-name, -set) |>
  left_join(country_last_update_info, by = "unit") |>
  filter(!is.na(last_update))
  
   data_summarized_over_time <- summarize_over_time(data_grpd, by_period = TRUE)
  data_summarized_over_group <- summarize_over_group(data_summarized_over_time, "country", by_period = TRUE)

```

`group_by_period()` is an exported function from the `timeseries` module